### PR TITLE
Fix typo in the signal_unread method. Closes: #5001

### DIFF
--- a/src/leap/mail/imap/mailbox.py
+++ b/src/leap/mail/imap/mailbox.py
@@ -707,7 +707,7 @@ class SoledadMailbox(WithMsgFields, MBoxParser):
         # this should really be called as a final callback of
         # the do_STORE method...
         from twisted.internet import reactor
-        deferLater(reactor, 1, self._signal_unread_to_ui)
+        deferLater(reactor, 1, self.signal_unread_to_ui)
         return result
 
     # ISearchableMailbox


### PR DESCRIPTION
It had been made public to be called from the overwritten methods
in service.imap
