### PR TITLE
Fix the fallback for the memoized call for bodies/content.

### DIFF
--- a/src/leap/mail/imap/memorystore.py
+++ b/src/leap/mail/imap/memorystore.py
@@ -230,10 +230,11 @@ class MemoryStore(object):
         self._add_message(mbox, uid, message, notify_on_disk)
         self._new.add(key)
 
-        def log_add(result):
-            log.msg("message save: %s" % result)
-            return result
-        observer.addCallback(log_add)
+        # XXX use this while debugging the callback firing,
+        # remove after unittesting this.
+        #def log_add(result):
+            #return result
+        #observer.addCallback(log_add)
 
         if notify_on_disk:
             # We store this deferred so we can keep track of the pending

--- a/src/leap/mail/imap/messageparts.py
+++ b/src/leap/mail/imap/messageparts.py
@@ -398,7 +398,7 @@ class MessagePart(object):
                 payload = ""
             else:
                 payload = self._get_payload_from_document_memoized(phash)
-                if payload is None:
+                if empty(payload):
                     payload = self._get_payload_from_document(phash)
 
         else:


### PR DESCRIPTION
Changed to "empty" to consider empty strings too.
