### PR TITLE
Implement non-synchronizing literals (rfc2088) Closes: #5190

### DIFF
--- a/changes/feature_literal-plus
+++ b/changes/feature_literal-plus
@@ -1,0 +1,2 @@
+  o Implement IMAP4 non-synchronizing literals (rfc2088), so APPENDs can be made
+    in a single round-trip. Closes: #5190


### PR DESCRIPTION
This also paves the way to MULTIAPPEND IMAP Extension (rfc3502)
Related to: Feature #5182
