### PR TITLE
workaround attempt for the recursionlimit bug with qtreactor.

### DIFF
--- a/src/leap/mail/imap/service/imap.py
+++ b/src/leap/mail/imap/service/imap.py
@@ -57,7 +57,7 @@ import resource
 import sys
 
 try:
-    sys.setrecursionlimit(10**6)
+    sys.setrecursionlimit(10**7)
 except Exception:
     print "Error setting recursion limit"
 try:


### PR DESCRIPTION
Increasing the recursion limit by an order of magnitude here seems to
allow a fetch of a mailbox with 500 mails.

See #5196 for discussion of alternatives.
