### PR TITLE
addMailbox shouldn't accept empty names.

### DIFF
--- a/changes/prevent-mailbox-with-blank-name
+++ b/changes/prevent-mailbox-with-blank-name
@@ -1,0 +1,3 @@
+  o account#addMailbox can't allow empty mailbox names since it makes it
+impossible to create it later (mailbox#__init__ will throw an error), which makes
+it impossible to getMailbox or even delete it

--- a/src/leap/mail/imap/account.py
+++ b/src/leap/mail/imap/account.py
@@ -187,6 +187,8 @@ class SoledadBackedAccount(WithMsgFields, IndexedDB, MBoxParser):
         """
         name = self._parse_mailbox_name(name)
 
+        leap_assert(name, "Need a mailbox name to create a mailbox")
+
         if name in self.mailboxes:
             raise imap4.MailboxCollision(repr(name))
 


### PR DESCRIPTION
Without this change it is possible to addMailbox with and empty name that can't be neither retrieved by getMailbox or deleted (because mailbox.py#**init** does a leap_assert on the name).
