### PR TITLE
The get_key cache now it's automagical

### DIFF
--- a/src/leap/mail/imap/fetch.py
+++ b/src/leap/mail/imap/fetch.py
@@ -433,7 +433,7 @@ class LeapIncomingMail(object):
                  or msg.get_content_type() == MULTIPART_SIGNED)):
             _, senderAddress = parseaddr(fromHeader)
             try:
-                senderPubkey = self._keymanager.get_key_from_cache(
+                senderPubkey = self._keymanager.get_key(
                     senderAddress, OpenPGPKey)
             except keymanager_errors.KeyNotFound:
                 pass


### PR DESCRIPTION
Needed by: https://github.com/leapcode/keymanager/pull/52
