### PR TITLE
Bug/save mail drafts

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,7 @@ copyright = u'2014, Kali Kaneko'
 # built documents.
 #
 # The short X.Y version.
-version = '0.3.9'
+version = '0.4.0alpha1'
 # The full version, including alpha/beta/rc tags.
 release = '0.3.9'
 

--- a/docs/hacking.rst
+++ b/docs/hacking.rst
@@ -1,0 +1,163 @@
+.. _hacking:
+
+========
+Hacking 
+========
+
+Some hints oriented to `leap.mail` hackers. These notes are mostly related to
+the imap server, although they probably will be useful for other pieces too.
+
+Don't panic! Just manhole into it
+=================================
+
+If you want to inspect the objects living in your application memory, in
+realtime, you can manhole into it.
+
+First of all, check that the modules ``PyCrypto`` and ``pyasn1`` are installed
+into your system, they are needed for it to work.
+
+You just have to pass the ``LEAP_MAIL_MANHOLE=1`` enviroment variable while
+launching the client::
+
+  LEAP_MAIL_MANHOLE=1 bitmask --debug
+
+And then you can ssh into your application! (password is "leap")::
+
+  ssh boss@localhost -p 2222
+
+Did I mention how *awesome* twisted is?? ``:)``
+
+
+Profiling
+=========
+If using ``twistd`` to launch the server, you can use twisted profiling
+capabities::
+
+  LEAP_MAIL_CONF=~/.leapmailrc twistd --profile=/tmp/mail-profiling -n -y imap-server.tac
+
+``--profiler`` option allows you to select different profilers (default is
+"hotshot").
+
+You can also do profiling when using the ``bitmask`` client. Enable the
+``LEAP_PROFILE_IMAPCMD`` environment flag to get profiling of certain IMAP
+commands::
+
+ LEAP_PROFILE_IMAPCMD=1 bitmask --debug
+
+Offline mode
+============
+
+The client has an ``--offline`` flag that will make the Mail services (imap,
+currently) not try to sync with remote replicas. Very useful during development,
+although you need to login with the remote server at least once before being
+able to use it.
+
+Running the service with twistd
+===============================
+
+In order to run the mail service (currently, the imap server only), you will
+need a config with this info::
+
+  [leap_mail]
+  userid = "user@provider"
+  uuid = "deadbeefdeadabad"
+  passwd = "foobar" # Optional
+
+In the ``LEAP_MAIL_CONF`` enviroment variable. If you do not specify a password
+parameter, you'll be prompted for it.
+
+In order to get the user uid (uuid), look into the
+``~/.config/leap/leap-backend.conf`` file after you have logged in into your
+provider at least once.
+
+Run the twisted service::
+
+  LEAP_IMAP_CONFIG=~/.leapmailrc twistd -n -y imap-server.tac
+
+Now you can telnet into your local IMAP server and read your mail like a real
+programmer™::
+
+  % telnet localhost 1984
+  Trying 127.0.0.1...
+  Connected to localhost.
+  Escape character is '^]'.
+  * OK [CAPABILITY IMAP4rev1 LITERAL+ IDLE NAMESPACE] Twisted IMAP4rev1 Ready
+  tag LOGIN me@myprovider.net mahsikret
+  tag OK LOGIN succeeded
+  tag SELECT Inbox
+  * 2 EXISTS
+  * 1 RECENT
+  * FLAGS (\Seen \Answered \Flagged \Deleted \Draft \Recent List)
+  * OK [UIDVALIDITY 1410453885932] UIDs valid
+  tag OK [READ-WRITE] SELECT successful
+  ^]
+  telnet> Connection closed.
+
+
+Although you probably prefer to use ``offlineimap`` for tests:: 
+
+  offlineimap -c LEAPofflineimapRC-tests
+
+
+Minimal offlineimap configuration
+---------------------------------
+
+You can use this as a sample offlineimap config file::
+
+  [general]
+  accounts = leap-local
+
+  [Account leap-local]
+  localrepository = LocalLeap
+  remoterepository = RemoteLeap
+
+  [Repository LocalLeap]
+  type = Maildir
+  localfolders = ~/LEAPMail/Mail
+
+  [Repository RemoteLeap]
+  type = IMAP
+  ssl = no
+  remotehost = localhost
+  remoteport = 1984
+  remoteuser = user
+  remotepass = pass
+
+Testing utilities
+-----------------
+There are a bunch of utilities to test IMAP delivery in ``imap/tests`` folder.
+If looking for a quick way of inspecting mailboxes, have a look at ``getmail``::
+
+ ./getmail me@testprovider.net mahsikret
+ 1. Drafts
+ 2. INBOX
+ 3. Trash
+ Which mailbox? [1] 2
+ 1 Subject: this is the time of the revolution
+ 2 Subject: ignore me
+
+ Which message? [1] (Q quits) 1
+ 1 X-Leap-Provenance: Thu, 11 Sep 2014 16:52:11 -0000; pubkey="C1F8DE10BD151F99"
+ Received: from mx1.testprovider.net(mx1.testprovider.net [198.197.196.195])
+ (using TLSv1.2 with cipher ECDHE-RSA-AES256-GCM-SHA384 (256/256 bits))
+ (Client CN "*.foobar.net", Issuer "Gandi Standard SSL CA" (not verified))
+ by blackhole (Postfix) with ESMTPS id DEADBEEF
+ for <me@testprovider.net>; Thu, 11 Sep 2014 16:52:10 +0000 (UTC)
+ Delivered-To: 926d4915cfd42b6d96d38660c04613af@testprovider.net
+ Message-Id: <20140911165205.GB8054@samsara>
+ From: Kali <kali@leap.se>
+ 
+ (snip)
+ 
+
+Debugging IMAP commands
+=======================
+
+Use ``ngrep`` to obtain logs of the commands::
+
+  sudo ngrep -d lo -W byline port 1984
+
+To get verbose output from thunderbird/icedove, set the following environment
+variable::
+
+  NSPR_LOG_MODULES="imap:5" icedove

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,8 @@ server as another code entity that uses this lower layer.
 .. toctree::
    :maxdepth: 2
 
+   hacking
+
 ..   intro
 ..   tutorial
 

--- a/src/leap/mail/adaptors/soledad.py
+++ b/src/leap/mail/adaptors/soledad.py
@@ -464,7 +464,7 @@ class MessageWrapper(object):
         cdocs_keys = cdocs.keys()
         assert sorted(cdocs_keys) == range(1, len(cdocs_keys) + 1)
         self.cdocs = dict([
-            (key, ContentDocWrapper(**doc.content))
+            (key, get_doc_wrapper(doc, ContentDocWrapper))
             for (key, doc) in cdocs.items()])
         for doc_id, cdoc in zip(self.mdoc.cdocs, self.cdocs.values()):
             cdoc.set_future_doc_id(doc_id)

--- a/src/leap/mail/adaptors/soledad.py
+++ b/src/leap/mail/adaptors/soledad.py
@@ -966,6 +966,30 @@ class SoledadMailAdaptor(SoledadIndexMixin):
         d.addErrback(self._errback)
         return d
 
+    # search api
+
+    def get_mdoc_id_from_msgid(self, store, mbox_uuid, msgid):
+        """
+        Get the UID for a message with the passed msgid (the one in the headers
+        msg-id).
+        This is used by the MUA to retrieve the recently saved draft.
+        """
+        type_ = HeaderDocWrapper.model.type_
+        uuid = mbox_uuid.replace('-', '_')
+
+        msgid_index = indexes.TYPE_MSGID_IDX
+
+        def get_mdoc_id(hdoc):
+            if not hdoc:
+                return None
+            hdoc = hdoc[0]
+            mdoc_id = hdoc.doc_id.replace("H-", "M-%s-" % uuid)
+            return mdoc_id
+
+        d = store.get_from_index(msgid_index, type_, msgid)
+        d.addCallback(get_mdoc_id)
+        return d
+
     # Mailbox handling
 
     def get_or_create_mbox(self, store, name):

--- a/src/leap/mail/imap/mailbox.py
+++ b/src/leap/mail/imap/mailbox.py
@@ -842,18 +842,17 @@ class IMAPMailbox(object):
         #   '52D44F11.9060107@dev.bitmask.net']
 
         # TODO hardcoding for now! -- we'll support generic queries later on
-        # but doing a quickfix for avoiding duplicat saves in the draft folder.
-        # See issue #4209
+        # but doing a quickfix for avoiding duplicate saves in the draft
+        # folder.  # See issue #4209
 
         if len(query) > 2:
             if query[1] == 'HEADER' and query[2].lower() == "message-id":
                 msgid = str(query[3]).strip()
                 logger.debug("Searching for %s" % (msgid,))
-                d = self.messages._get_uid_from_msgid(str(msgid))
-                # XXX remove gatherResults
-                d1 = defer.gatherResults([d])
-                # we want a list, so return it all the same
-                return d1
+
+                d = self.collection.get_uid_from_msgid(str(msgid))
+                d.addCallback(lambda result: [result])
+                return d
 
         # nothing implemented for any other query
         logger.warning("Cannot process query: %s" % (query,))

--- a/src/leap/mail/imap/mailbox.py
+++ b/src/leap/mail/imap/mailbox.py
@@ -521,7 +521,7 @@ class IMAPMailbox(object):
         getmsg = self.collection.get_message_by_uid
         getimapmsg = self.get_imap_message
 
-        def get_imap_messages_for_sequence(msg_sequence):
+        def get_imap_messages_for_range(msg_range):
 
             def _get_imap_msg(messages):
                 d_imapmsg = []
@@ -531,7 +531,7 @@ class IMAPMailbox(object):
 
             def _zip_msgid(imap_messages):
                 zipped = zip(
-                    list(msg_sequence), imap_messages)
+                    list(msg_range), imap_messages)
                 return (item for item in zipped)
 
             def _unset_recent(sequence):
@@ -539,7 +539,7 @@ class IMAPMailbox(object):
                 return sequence
 
             d_msg = []
-            for msgid in msg_sequence:
+            for msgid in msg_range:
                 # XXX We want cdocs because we "probably" are asked for the
                 # body. We should be smarted at do_FETCH and pass a parameter
                 # to this method in order not to prefetch cdocs if they're not
@@ -558,7 +558,7 @@ class IMAPMailbox(object):
 
         else:
             d = self._get_messages_range(messages_asked)
-            d.addCallback(get_imap_messages_for_sequence)
+            d.addCallback(get_imap_messages_for_range)
 
         # TODO -- call signal_to_ui
         # d.addCallback(self.cb_signal_unread_to_ui)

--- a/src/leap/mail/mail.py
+++ b/src/leap/mail/mail.py
@@ -22,7 +22,6 @@ import logging
 import StringIO
 
 from twisted.internet import defer
-from twisted.python import log
 
 from leap.common.check import leap_assert_type
 from leap.common.mail import get_email_charset
@@ -31,7 +30,6 @@ from leap.mail.adaptors.soledad import SoledadMailAdaptor
 from leap.mail.constants import INBOX_NAME
 from leap.mail.constants import MessageFlags
 from leap.mail.mailbox_indexer import MailboxIndexer
-from leap.mail.utils import empty  # find_charset
 
 logger = logging.getLogger(name=__name__)
 
@@ -211,9 +209,8 @@ class Message(object):
         Get a file descriptor with the body content.
         """
         def write_and_rewind_if_found(cdoc):
-            if not cdoc:
-                return None
-            return _write_and_rewind(cdoc.raw)
+            payload = cdoc.raw if cdoc else ""
+            return _write_and_rewind(payload)
 
         d = defer.maybeDeferred(self._wrapper.get_body, store)
         d.addCallback(write_and_rewind_if_found)

--- a/src/leap/mail/mail.py
+++ b/src/leap/mail/mail.py
@@ -460,6 +460,25 @@ class MessageCollection(object):
         """
         return self.mbox_indexer.all_uid_iter(self.mbox_uuid)
 
+    def get_uid_from_msgid(self, msgid):
+        """
+        Return the UID(s) of the matching msg-ids for this mailbox collection.
+        """
+        if not self.is_mailbox_collection():
+            raise NotImplementedError()
+
+        def get_uid(mdoc_id):
+            if not mdoc_id:
+                return None
+            d = self.mbox_indexer.get_uid_from_doc_id(
+                self.mbox_uuid, mdoc_id)
+            return d
+
+        d = self.adaptor.get_mdoc_id_from_msgid(
+            self.store, self.mbox_uuid, msgid)
+        d.addCallback(get_uid)
+        return d
+
     # Manipulate messages
 
     def add_msg(self, raw_msg, flags=tuple(), tags=tuple(), date=""):

--- a/src/leap/mail/mailbox_indexer.py
+++ b/src/leap/mail/mailbox_indexer.py
@@ -120,7 +120,7 @@ class MailboxIndexer(object):
 
         The doc_id must be in the format:
 
-            M+<mailbox>+<content-hash-of-the-message>
+            M-<mailbox>-<content-hash-of-the-message>
 
         :param mailbox: the mailbox name
         :type mailbox: str

--- a/src/leap/mail/walk.py
+++ b/src/leap/mail/walk.py
@@ -62,7 +62,8 @@ def get_body_phash(msg):
     Find the body payload-hash for this message.
     """
     for part in msg.walk():
-        if part.get_content_type() == "text/plain":
+        # XXX what other ctypes should be considered body?
+        if part.get_content_type() in ("text/plain", "text/html"):
             # XXX avoid hashing again
             return get_hash(part.get_payload())
 


### PR DESCRIPTION
The save-drafts functionality in thunderbird is working again (it uses the search api, that we only implement partially).
It fixes also some bugs with appending, and missing bodies if they were in text/html.