### PR TITLE
[bug] fixes for display attachments and move between folders

### DIFF
--- a/src/leap/mail/imap/mailbox.py
+++ b/src/leap/mail/imap/mailbox.py
@@ -846,8 +846,9 @@ class IMAPMailbox(object):
         #deferLater(self.reactor, 0, self._do_copy, message, d)
         #return d
 
-        return self.collection.copy_msg(message.message,
-                                        self.collection.mbox_uuid)
+        d = self.collection.copy_msg(message.message,
+                                     self.collection.mbox_uuid)
+        return d
 
     # convenience fun
 

--- a/src/leap/mail/mailbox_indexer.py
+++ b/src/leap/mail/mailbox_indexer.py
@@ -104,7 +104,6 @@ class MailboxIndexer(object):
                "uid  INTEGER PRIMARY KEY AUTOINCREMENT, "
                "hash TEXT UNIQUE NOT NULL)".format(
                    preffix=self.table_preffix, name=sanitize(mailbox_uuid)))
-        print "CREATING TABLE..."
         return self._operation(sql)
 
     def delete_table(self, mailbox_uuid):
@@ -190,8 +189,7 @@ class MailboxIndexer(object):
         :type mailbox: str
         :param doc_id: the doc_id for the MetaMsg
         :type doc_id: str
-        :return: a deferred that will fire with the uid of the newly inserted
-                 document.
+        :return: a deferred that will fire when the deletion has succed.
         :rtype: Deferred
         """
         check_good_uuid(mailbox_uuid)

--- a/src/leap/mail/sync_hooks.py
+++ b/src/leap/mail/sync_hooks.py
@@ -86,7 +86,7 @@ class MailProcessingPostSyncHook(object):
             # have seen -- but make sure *it's already created* before
             # inserting the index entry!.
             d = indexer.create_table(mbox_uuid)
-            d.addCallback(lambda _: indexer.insert_doc(mbox_uuid, index_docid))
+            d.addBoth(lambda _: indexer.insert_doc(mbox_uuid, index_docid))
             self._processing_deferreds.append(d)
 
     def _process_queued_docs(self):


### PR DESCRIPTION
- Add errback handling to catch properly errors that were not allowing
  the complete insertion of the parts for a given message. Fixes blank
  attachments and moving of messages to different folders.
- Force overwritting of mdoc when it is a copy. This was avoiding a
  message to be copied back to a folder from where it already had been
  copied to another (since the mdoc was already existing there, with the
  same doc_id, which was forbidding the creation of the new one).
  This case also needs special care in the indexer, since we have to
  delete the old hash entry first.

Closes: #7178, #7158