### PR TITLE
[bug] allow mailbox to be notified of collection changes

### DIFF
--- a/src/leap/mail/adaptors/soledad.py
+++ b/src/leap/mail/adaptors/soledad.py
@@ -505,6 +505,8 @@ class MessageWrapper(object):
             (key, get_doc_wrapper(doc, ContentDocWrapper))
             for (key, doc) in cdocs.items()])
         for doc_id, cdoc in zip(self.mdoc.cdocs, self.cdocs.values()):
+            if cdoc.raw == "":
+                log.msg("Empty raw field in cdoc %s" % doc_id)
             cdoc.set_future_doc_id(doc_id)
 
     def create(self, store, notify_just_mdoc=False, pending_inserts_dict={}):


### PR DESCRIPTION
in a previous refactor, we decoupled the incoming mail service from the
IMAP layer. However, this left the IMAPMailbox unable to react to
changes in the underlying collection when a new message is inserted.

in this commit, we add a Listener mechanism to the collection itself, so
that IMAPMailbox (and any other object that uses it) can subscribe to
changes on the number of messages of the collection.

Resolves: #7191
Releases: 0.4.0