### PR TITLE
[bug] return the wrapper, not the soledad doc

### DIFF
--- a/src/leap/mail/adaptors/soledad.py
+++ b/src/leap/mail/adaptors/soledad.py
@@ -119,8 +119,8 @@ class SoledadDocumentWrapper(models.DocumentWrapper):
         instead (that's the preferred way of creating documents from
         the wrapper object).
 
-        :return: a deferred that will fire when the underlying
-                 Soledad document has been created.
+        :return: a deferred that will fire with this SoledadDocumentWrapper
+                 when the underlying Soledad document has been created.
         :rtype: Deferred
         """
         leap_assert(self._doc_id is None,
@@ -129,7 +129,7 @@ class SoledadDocumentWrapper(models.DocumentWrapper):
         def update_doc_id(doc):
             self._doc_id = doc.doc_id
             self.set_future_doc_id(None)
-            return doc
+            return self
 
         def update_wrapper(failure):
             # In the case of some copies (for instance, from one folder to

--- a/src/leap/mail/mail.py
+++ b/src/leap/mail/mail.py
@@ -619,8 +619,8 @@ class MessageCollection(object):
             doc_id = wrapper.mdoc.doc_id
             if not doc_id:
                 # --- BUG -----------------------------------------
-                # XXX why from time to time mdoc doesn't have doc_id
-                # here???
+                # XXX watch out, sometimes mdoc doesn't have doc_id
+                # but it has future_id. Should be solved already.
                 logger.error("BUG: (please report) Null doc_id for "
                              "document %s" %
                              (wrapper.mdoc.serialize(),))


### PR DESCRIPTION
callbacks on the creation deferred were assuming that the mdoc doc_id
was going to be updated on creation, but here we were returning a
soledad document, not the wrapper itself (that is where the future_id
has been moved to the actual doc_id).

this should fix a problem in which mdocs sometimes do not have a doc_id
to be inserted in the UID hash table. it's related to the sporadic
failure to insert a message when "moving" to a different folder.