### PR TITLE
[pkg] separate leap requirements

### DIFF
--- a/pkg/requirements-leap.pip
+++ b/pkg/requirements-leap.pip
@@ -1,0 +1,3 @@
+leap.common>=0.4.0
+leap.soledad.client>=0.7.0
+leap.keymanager>=0.4.0

--- a/pkg/requirements.pip
+++ b/pkg/requirements.pip
@@ -1,7 +1,4 @@
 zope.interface
-leap.soledad.client>=0.7.0
-leap.common>=0.4.0
-leap.keymanager>=0.4.0
 twisted  # >= 12.0.3 ??
 zope.proxy
 service-identity

--- a/pkg/utils.py
+++ b/pkg/utils.py
@@ -14,20 +14,34 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 """
 Utils to help in the setup process
 """
-
 import os
 import re
 import sys
 
 
+def is_develop_mode():
+    """
+    Returns True if we're calling the setup script using the argument for
+    setuptools development mode.
+
+    This avoids messing up with dependency pinning and order, the
+    responsibility of installing the leap dependencies is left to the
+    developer.
+    """
+    args = sys.argv
+    devflags = "setup.py", "develop"
+    if (args[0], args[1]) == devflags:
+        return True
+    return False
+
+
 def get_reqs_from_files(reqfiles):
     """
     Returns the contents of the top requirement file listed as a
-    string list with the lines
+    string list with the lines.
 
     @param reqfiles: requirement files to parse
     @type reqfiles: list of str
@@ -42,6 +56,9 @@ def parse_requirements(reqfiles=['requirements.txt',
                                  'pkg/requirements.pip']):
     """
     Parses the requirement files provided.
+
+    The passed reqfiles list is a list of possible locations to try, the
+    function will return the contents of the first path found.
 
     Checks the value of LEAP_VENV_SKIP_PYSIDE to see if it should
     return PySide as a dep or not. Don't set, or set to 0 if you want
@@ -58,9 +75,9 @@ def parse_requirements(reqfiles=['requirements.txt',
         if re.match(r'\s*-e\s+', line):
             pass
             # do not try to do anything with externals on vcs
-            #requirements.append(re.sub(r'\s*-e\s+.*#egg=(.*)$', r'\1',
-                                #line))
-        # http://foo.bar/baz/foobar/zipball/master#egg=foobar
+            # requirements.append(re.sub(r'\s*-e\s+.*#egg=(.*)$', r'\1',
+            # line))
+            # http://foo.bar/baz/foobar/zipball/master#egg=foobar
         elif re.match(r'\s*https?:', line):
             requirements.append(re.sub(r'\s*https?:.*#egg=(.*)$', r'\1',
                                 line))

--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,22 @@ cmdclass["freeze_debianver"] = freeze_debianver
 
 # XXX add ref to docs
 
+requirements = utils.parse_requirements()
+
+if utils.is_develop_mode():
+    print
+    print ("[WARNING] Skipping leap-specific dependencies "
+           "because development mode is detected.")
+    print ("[WARNING] You can install "
+           "the latest published versions with "
+           "'pip install -r pkg/requirements-leap.pip'")
+    print ("[WARNING] Or you can instead do 'python setup.py develop' "
+           "from the parent folder of each one of them.")
+    print
+else:
+    requirements += utils.parse_requirements(
+        reqfiles=["pkg/requirements-leap.pip"])
+
 setup(
     name='leap.mail',
     version=VERSION,
@@ -130,7 +146,7 @@ setup(
     package_dir={'': 'src'},
     packages=find_packages('src'),
     test_suite='leap.mail.load_tests.load_tests',
-    install_requires=utils.parse_requirements(),
+    install_requires=requirements,
     tests_require=utils.parse_requirements(
         reqfiles=['pkg/requirements-testing.pip']),
 )


### PR DESCRIPTION
this is part of a process to make the setup of the development mode less
troublesome. from now on, setting up a virtualenv in pure development
mode will be as easy as telling pip to just install the external
dependencies::

  pip install -r pkg/requirements.pip

and traversing all the leap repos for the needed leap dependencies doing::

  python setup.py develop

- Related: #7288