### PR TITLE
Revert "Port `enum` to `enum34`"

### DIFF
--- a/pkg/requirements.pip
+++ b/pkg/requirements.pip
@@ -4,4 +4,4 @@ leap.common>=0.3.7
 leap.keymanager>=0.3.8
 #twisted  # removed for debian package
 zope.proxy
-enum34
+enum

--- a/src/leap/mail/imap/memorystore.py
+++ b/src/leap/mail/imap/memorystore.py
@@ -52,10 +52,10 @@ logger = logging.getLogger(__name__)
 # soledad storage, in seconds.
 SOLEDAD_WRITE_PERIOD = 15
 
-FDOC = MessagePartType.fdoc.name
-HDOC = MessagePartType.hdoc.name
-CDOCS = MessagePartType.cdocs.name
-DOCS_ID = MessagePartType.docs_id.name
+FDOC = MessagePartType.fdoc.key
+HDOC = MessagePartType.hdoc.key
+CDOCS = MessagePartType.cdocs.key
+DOCS_ID = MessagePartType.docs_id.key
 
 
 @contextlib.contextmanager
@@ -73,7 +73,7 @@ def set_bool_flag(obj, att):
         setattr(obj, att, False)
 
 
-DirtyState = Enum("DirtyState", "none dirty new")
+DirtyState = Enum("none", "dirty", "new")
 
 
 class MemoryStore(object):

--- a/src/leap/mail/imap/messageparts.py
+++ b/src/leap/mail/imap/messageparts.py
@@ -32,7 +32,7 @@ from leap.mail.imap import interfaces
 from leap.mail.imap.fields import fields
 from leap.mail.utils import empty, first, find_charset
 
-MessagePartType = Enum("MessagePartType", "hdoc fdoc cdoc cdocs docs_id")
+MessagePartType = Enum("hdoc", "fdoc", "cdoc", "cdocs", "docs_id")
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
This reverts commit 16920c065430c9892599b8b803aa6bbd4cd4f933.

this commit never was merged back to develop and it creates merge
conflicts when trying to merge develop into debian/experimental