### PR TITLE
Skip instead of fail on not implemented behavior

### DIFF
--- a/pkg/requirements-latest.pip
+++ b/pkg/requirements-latest.pip
@@ -1,0 +1,9 @@
+--index-url https://pypi.python.org/simple/
+
+--allow-external u1db  --allow-unverified u1db
+--allow-external dirspec  --allow-unverified dirspec
+-e 'git+https://github.com/pixelated-project/leap_pycommon.git@develop#egg=leap.common'
+-e 'git+https://github.com/pixelated-project/soledad.git@develop#egg=leap.soledad.common&subdirectory=common/'
+-e 'git+https://github.com/pixelated-project/soledad.git@develop#egg=leap.soledad.client&subdirectory=client/'
+-e 'git+https://github.com/pixelated-project/keymanager.git@develop#egg=leap.keymanager'
+-e .

--- a/src/leap/mail/adaptors/tests/test_soledad_adaptor.py
+++ b/src/leap/mail/adaptors/tests/test_soledad_adaptor.py
@@ -364,7 +364,7 @@ class SoledadMailAdaptorTestCase(SoledadTestMixin):
 
     def test_get_msg_from_metamsg_doc_id(self):
         # TODO complete-me!
-        self.fail()
+        self.skipTest("Not yet implemented")
 
     def test_create_msg(self):
         adaptor = self.get_adaptor()

--- a/src/leap/mail/imap/tests/test_imap_store_fetch.py
+++ b/src/leap/mail/imap/tests/test_imap_store_fetch.py
@@ -14,9 +14,9 @@ class StoreAndFetchTestCase(IMAP4HelperMixin):
     """
 
     def setUp(self):
-        IMAP4HelperMixin.setUp(self)
         self.received_messages = self.received_uid = None
         self.result = None
+        return IMAP4HelperMixin.setUp(self)
 
     def addListener(self, x):
         pass

--- a/src/leap/mail/tests/test_mail.py
+++ b/src/leap/mail/tests/test_mail.py
@@ -271,7 +271,7 @@ class MessageCollectionTestCase(SoledadTestMixin, CollectionMixin):
     def test_copy_msg(self):
         # TODO ---- update when implementing messagecopier
         # interface
-        self.fail("Not Yet Implemented")
+        self.skipTest("Not yet implemented")
 
     def test_delete_msg(self):
         d = self.add_msg_to_collection()
@@ -390,7 +390,7 @@ class AccountTestCase(SoledadTestMixin):
     # XXX not yet implemented
 
     def test_get_collection_by_docs(self):
-        self.fail("Not Yet Implemented")
+        self.skipTest("Not Yet Implemented")
 
     def test_get_collection_by_tag(self):
-        self.fail("Not Yet Implemented")
+        self.skipTest("Not Yet Implemented")


### PR DESCRIPTION
Hey, I changed the leap mail tests to make sure it skips not implemented behavior instead of calling .fail() . This way you still have a reminder that you have to implement that, but it doesn't break the tests.

IMAP Mixin was being initialized without handling, but it returns a deferred, the deferred was being collected before it was run, and that was breaking the imap tests (that depended on the result of that deferred). The IMAP fetch tests still need to be fixed because they are outdated and they can't handle callbacks (some of the class methods changed and the part of the test still expects synchronous code)