### PR TITLE
Fix two bugs when converting multipart mails to ContentDocWrappers

### DIFF
--- a/src/leap/mail/adaptors/models.py
+++ b/src/leap/mail/adaptors/models.py
@@ -76,7 +76,7 @@ class DocumentWrapper(object):
 
         if kwargs:
             values = copy.deepcopy(defaults)
-            values.update(kwargs)
+            values.update(_normalize_dict(kwargs))
         else:
             values = defaults
 

--- a/src/leap/mail/adaptors/tests/test_soledad_adaptor.py
+++ b/src/leap/mail/adaptors/tests/test_soledad_adaptor.py
@@ -342,6 +342,7 @@ class SoledadMailAdaptorTestCase(SoledadTestMixin):
         msg = adaptor.get_msg_from_string(TestMessageClass, msg.as_string())
 
         self.assertEqual('base64', msg.wrapper.cdocs[1].content_transfer_encoding)
+        self.assertEqual('text/plain; charset="utf-8"', msg.wrapper.cdocs[1].content_type)
         self.assertEqual('YSB1dGY4IG1lc3NhZ2U=\n', msg.wrapper.cdocs[1].raw)
 
     def test_get_msg_from_docs(self):

--- a/src/leap/mail/adaptors/tests/test_soledad_adaptor.py
+++ b/src/leap/mail/adaptors/tests/test_soledad_adaptor.py
@@ -28,6 +28,9 @@ from leap.mail.adaptors.soledad import SoledadIndexMixin
 from leap.mail.adaptors.soledad import SoledadMailAdaptor
 from leap.mail.tests.common import SoledadTestMixin
 
+from email.MIMEMultipart import MIMEMultipart
+from email.mime.text import MIMEText
+
 # DEBUG
 # import logging
 # logging.basicConfig(level=logging.DEBUG)
@@ -329,6 +332,17 @@ class SoledadMailAdaptorTestCase(SoledadTestMixin):
                          subject)
         self.assertEqual(msg.wrapper.hdoc.subject, subject)
         self.assertEqual(msg.wrapper.cdocs[1].phash, phash)
+
+    def test_get_msg_from_string_multipart(self):
+        msg = MIMEMultipart()
+        msg['Subject'] = 'Test multipart mail'
+        msg.attach(MIMEText(u'a utf8 message', _charset='utf-8'))
+        adaptor = self.get_adaptor()
+
+        msg = adaptor.get_msg_from_string(TestMessageClass, msg.as_string())
+
+        self.assertEqual('base64', msg.wrapper.cdocs[1].content_transfer_encoding)
+        self.assertEqual('YSB1dGY4IG1lc3NhZ2U=\n', msg.wrapper.cdocs[1].raw)
 
     def test_get_msg_from_docs(self):
         adaptor = self.get_adaptor()

--- a/src/leap/mail/walk.py
+++ b/src/leap/mail/walk.py
@@ -99,7 +99,7 @@ def get_raw_docs(msg, parts):
             "content-type": headers.get(
                 'content-type', ''),
             "content-transfer-encoding": headers.get(
-                'content-transfer-type', '')
+                'content-transfer-encoding', '')
         } for payload, headers in get_payloads(msg)
         if not isinstance(payload, list))
 


### PR DESCRIPTION
[bug] Fix missing _normailize_dict in DocumentWrapper constructor.

In the constructor values already is normalized (i.e. with underscores),
while kwargs contains items that are not normalized (i.e. with dashes).
Joining the dicts resulted in two entries that only differed by dash or
underscores. The setattr then set the value that occurred later in
items, thereby sometimes overriding the correct value with the default
one.

[bug] Fix typo in content-transfer-encoding in walk.py.

The get_raw_docs method accesses header field content-transfer-encoding
using the string 'content-transfer-type' so the raw doc dict always ends
up with that value set to empty string.