### PR TITLE
When message is decrypted in IncomingMail, add decrypted header to it

### DIFF
--- a/src/leap/mail/incoming/service.py
+++ b/src/leap/mail/incoming/service.py
@@ -465,7 +465,8 @@ class IncomingMail(Service):
         return d
 
     def _add_decrypted_header(self, msg):
-        msg.add_header(self.LEAP_ENCRYPTION_HEADER, self.LEAP_ENCRYPTION_DECRYPTED)
+        msg.add_header(self.LEAP_ENCRYPTION_HEADER,
+                       self.LEAP_ENCRYPTION_DECRYPTED)
 
     def _decrypt_multipart_encrypted_msg(self, msg, encoding, senderAddress):
         """

--- a/src/leap/mail/incoming/service.py
+++ b/src/leap/mail/incoming/service.py
@@ -90,6 +90,7 @@ class IncomingMail(Service):
     CONTENT_KEY = "content"
 
     LEAP_SIGNATURE_HEADER = 'X-Leap-Signature'
+    LEAP_ENCRYPTION_HEADER = 'X-Leap-Encryption'
     """
     Header added to messages when they are decrypted by the fetcher,
     which states the validity of an eventual signature that might be included
@@ -98,6 +99,8 @@ class IncomingMail(Service):
     LEAP_SIGNATURE_VALID = 'valid'
     LEAP_SIGNATURE_INVALID = 'invalid'
     LEAP_SIGNATURE_COULD_NOT_VERIFY = 'could not verify'
+
+    LEAP_ENCRYPTION_DECRYPTED = 'decrypted'
 
     def __init__(self, keymanager, soledad, inbox, userid,
                  check_period=INCOMING_CHECK_PERIOD):
@@ -461,6 +464,9 @@ class IncomingMail(Service):
         d.addCallback(add_leap_header)
         return d
 
+    def _add_decrypted_header(self, msg):
+        msg.add_header(self.LEAP_ENCRYPTION_HEADER, self.LEAP_ENCRYPTION_DECRYPTED)
+
     def _decrypt_multipart_encrypted_msg(self, msg, encoding, senderAddress):
         """
         Decrypt a message with content-type 'multipart/encrypted'.
@@ -503,6 +509,7 @@ class IncomingMail(Service):
 
             # all ok, replace payload by unencrypted payload
             msg.set_payload(decrmsg.get_payload())
+            self._add_decrypted_header(msg)
             return (msg, signkey)
 
         d = self._keymanager.decrypt(
@@ -537,7 +544,9 @@ class IncomingMail(Service):
 
         def decrypted_data(res):
             decrdata, signkey = res
-            return data.replace(pgp_message, decrdata), signkey
+            replaced_data = data.replace(pgp_message, decrdata)
+            self._add_decrypted_header(origmsg)
+            return replaced_data, signkey
 
         def encode_and_return(res):
             data, signkey = res

--- a/src/leap/mail/incoming/tests/test_incoming_mail.py
+++ b/src/leap/mail/incoming/tests/test_incoming_mail.py
@@ -182,7 +182,7 @@ subject: independence of cyberspace
                 self.headers = {}
 
             def add_header(self, k, v):
-                self.headers[k]=v
+                self.headers[k] = v
 
         msg = DummyMsg()
         self.fetcher._add_decrypted_header(msg)
@@ -217,10 +217,7 @@ subject: independence of cyberspace
 
         def add_decrypted_header_called(_):
             self.assertTrue(self.fetcher._add_decrypted_header.called,
-                             "There was some errors with decryption")
-
-
-
+                            "There was some errors with decryption")
 
         d = self._km.encrypt(
             self.EMAIL,

--- a/src/leap/mail/incoming/tests/test_incoming_mail.py
+++ b/src/leap/mail/incoming/tests/test_incoming_mail.py
@@ -176,8 +176,22 @@ subject: independence of cyberspace
         d.addCallback(put_raw_key_called)
         return d
 
+    def testAddDecryptedHeader(self):
+        class DummyMsg():
+            def __init__(self):
+                self.headers = {}
+
+            def add_header(self, k, v):
+                self.headers[k]=v
+
+        msg = DummyMsg()
+        self.fetcher._add_decrypted_header(msg)
+
+        self.assertEquals(msg.headers['X-Leap-Encryption'], 'decrypted')
+
     def testDecryptEmail(self):
         self.fetcher._decryption_error = Mock()
+        self.fetcher._add_decrypted_header = Mock()
 
         def create_encrypted_message(encstr):
             message = Parser().parsestr(self.EMAIL)
@@ -198,8 +212,15 @@ subject: independence of cyberspace
             return newmsg
 
         def decryption_error_not_called(_):
-            self.assertFalse(self.fetcher._decyption_error.called,
+            self.assertFalse(self.fetcher._decryption_error.called,
                              "There was some errors with decryption")
+
+        def add_decrypted_header_called(_):
+            self.assertTrue(self.fetcher._add_decrypted_header.called,
+                             "There was some errors with decryption")
+
+
+
 
         d = self._km.encrypt(
             self.EMAIL,


### PR DESCRIPTION
We are doing so so that we can know later if that message was originally an encrypted message. We want to tell the user that they can be cool about a message they are reading since that message came in encrypted.

We had that information on X-Leap-Signature for signatures, now we are adding X-Leap-Encryption for encryption stats.

If the header isn't there you can assume the message came in as plain text.

All feedback is more than welcome :)

Thanks,

Duda/Bruno.