### PR TITLE
[bug] don't extract openpgp header if valid attached key

### DIFF
--- a/changes/bug-7480_extract_attach_and_openpgp
+++ b/changes/bug-7480_extract_attach_and_openpgp
@@ -1,0 +1,1 @@
+- don't extract openpgp header if valid attached key (Closes: #7480)

--- a/src/leap/mail/tests/__init__.py
+++ b/src/leap/mail/tests/__init__.py
@@ -91,7 +91,7 @@ class TestCaseWithKeyManager(unittest.TestCase, BaseLeapTest):
 
         nickserver_url = ''  # the url of the nickserver
         self._km = KeyManager(address, nickserver_url, self._soledad,
-                              ca_cert_path='', gpgbinary=self.GPG_BINARY_PATH)
+                              gpgbinary=self.GPG_BINARY_PATH)
         self._km._fetcher.put = Mock()
         self._km._fetcher.get = Mock(return_value=Response())
 


### PR DESCRIPTION
The key extracto should check first for attached keys and if this fails
then should try the OpenPGP header.

- Resolves: #7480