### PR TITLE
[bug] Make _collection_mapping a instance variable

### DIFF
--- a/src/leap/mail/mail.py
+++ b/src/leap/mail/mail.py
@@ -916,17 +916,19 @@ class Account(object):
 
     adaptor_class = SoledadMailAdaptor
 
-    # This is a mapping to collection instances so that we always
-    # return a reference to them instead of creating new ones. However, being a
-    # dictionary of weakrefs values, they automagically vanish from the dict
-    # when no hard refs is left to them (so they can be garbage collected)
-    # This is important because the different wrappers rely on several
-    # kinds of deferredLocks that are kept as class or instance variables
-    _collection_mapping = weakref.WeakValueDictionary()
-
     def __init__(self, store, ready_cb=None):
         self.store = store
         self.adaptor = self.adaptor_class()
+
+        # this is a mapping to collection instances so that we always
+        # return a reference to them instead of creating new ones. however,
+        # being a dictionary of weakrefs values, they automagically vanish
+        # from the dict when no hard refs is left to them (so they can be
+        # garbage collected) this is important because the different wrappers
+        # rely on several kinds of deferredlocks that are kept as class or
+        # instance variables
+        self._collection_mapping = weakref.WeakValueDictionary()
+
         self.mbox_indexer = MailboxIndexer(self.store)
 
         # This flag is only used from the imap service for the moment.

--- a/src/leap/mail/outgoing/service.py
+++ b/src/leap/mail/outgoing/service.py
@@ -241,7 +241,7 @@ class OutgoingMail:
 
         def signal_encrypt_sign(newmsg):
             emit_async(catalog.SMTP_END_ENCRYPT_AND_SIGN,
-                 "%s,%s" % (self._from_address, to_address))
+                       "%s,%s" % (self._from_address, to_address))
             return newmsg, recipient
 
         def if_key_not_found_send_unencrypted(failure, message):
@@ -260,7 +260,7 @@ class OutgoingMail:
         log.msg("Will encrypt the message with %s and sign with %s."
                 % (to_address, from_address))
         emit_async(catalog.SMTP_START_ENCRYPT_AND_SIGN,
-             "%s,%s" % (self._from_address, to_address))
+                   "%s,%s" % (self._from_address, to_address))
         d = self._maybe_attach_key(origmsg, from_address, to_address)
         d.addCallback(maybe_encrypt_and_sign)
         return d

--- a/src/leap/mail/smtp/gateway.py
+++ b/src/leap/mail/smtp/gateway.py
@@ -204,7 +204,8 @@ class SMTPDelivery(object):
         # verify if recipient key is available in keyring
         def found(_):
             log.msg("Accepting mail for %s..." % user.dest.addrstr)
-            emit_async(catalog.SMTP_RECIPIENT_ACCEPTED_ENCRYPTED, user.dest.addrstr)
+            emit_async(catalog.SMTP_RECIPIENT_ACCEPTED_ENCRYPTED,
+                       user.dest.addrstr)
 
         def not_found(failure):
             failure.trap(KeyNotFound)


### PR DESCRIPTION
As a class variable multiple account instances share
mailboxes which is bad if its different users or tests

This problem also made the tests flaky, the sometimes failed for a hard to detect reason - mails from previous tests remained.
