### PR TITLE
[bug] signal expired auth token to the GUI

### DIFF
--- a/changes/bug-7430_signal_InvalidAuthTokenError
+++ b/changes/bug-7430_signal_InvalidAuthTokenError
@@ -1,0 +1,1 @@
+- If the auth token has expired signal the GUI to request her to log in again (Closes: #7430)


### PR DESCRIPTION
In case of InvalidAuthTokeError from soledad sync we need signal the GUI, so
it will request her to log in again.

- Resolves: #7430