### PR TITLE
[feat] credentials handling: use twisted.cred

### DIFF
--- a/changes/next-changelog.rst
+++ b/changes/next-changelog.rst
@@ -11,6 +11,9 @@ I've added a new category `Misc` so we can track doc/style/packaging stuff.
 Features
 ~~~~~~~~
 - `#7656 <https://leap.se/code/issues/7656>`_: Emit multi-user aware events.
+- `#4008 <https://leap.se/code/issues/4008>`_: Add token-based authentication to local IMAP/SMTP services.
+- Use twisted.cred to authenticate IMAP users.
+
 - `#1234 <https://leap.se/code/issues/1234>`_: Description of the new feature corresponding with issue #1234.
 - New feature without related issue number.
 
@@ -18,6 +21,7 @@ Bugfixes
 ~~~~~~~~
 - `#1235 <https://leap.se/code/issues/1235>`_: Description for the fixed stuff corresponding with issue #1235.
 - Fix the get_body logic for corner-cases in which body is None (yet-to-be synced docs, mainly).
+
 - Bugfix without related issue number.
 
 Misc

--- a/src/leap/mail/imap/account.py
+++ b/src/leap/mail/imap/account.py
@@ -49,6 +49,7 @@ if PROFILE_CMD:
 # Soledad IMAP Account
 #######################################
 
+
 class IMAPAccount(object):
     """
     An implementation of an imap4 Account
@@ -68,8 +69,8 @@ class IMAPAccount(object):
         You can either pass a deferred to this constructor, or use
         `callWhenReady` method.
 
-        :param user_id: The name of the account (user id, in the form
-                        user@provider).
+        :param user_id: The identifier of the user this account belongs to
+                        (user id, in the form user@provider).
         :type user_id: str
 
         :param store: a Soledad instance.

--- a/src/leap/mail/imap/server.py
+++ b/src/leap/mail/imap/server.py
@@ -20,15 +20,9 @@ LEAP IMAP4 Server Implementation.
 import StringIO
 from copy import copy
 
-from twisted import cred
-from twisted.internet import reactor
 from twisted.internet.defer import maybeDeferred
 from twisted.mail import imap4
 from twisted.python import log
-
-from leap.common.check import leap_assert, leap_assert_type
-from leap.common.events import emit_async, catalog
-from leap.soledad.client import Soledad
 
 # imports for LITERAL+ patch
 from twisted.internet import defer, interfaces
@@ -72,25 +66,6 @@ class LEAPIMAPServer(imap4.IMAP4Server):
     """
     An IMAP4 Server with a LEAP Storage Backend.
     """
-    def __init__(self, *args, **kwargs):
-        # pop extraneous arguments
-        soledad = kwargs.pop('soledad', None)
-        uuid = kwargs.pop('uuid', None)
-        userid = kwargs.pop('userid', None)
-
-        leap_assert(soledad, "need a soledad instance")
-        leap_assert_type(soledad, Soledad)
-        leap_assert(uuid, "need a user in the initialization")
-
-        self._userid = userid
-
-        # initialize imap server!
-        imap4.IMAP4Server.__init__(self, *args, **kwargs)
-
-        # we should initialize the account here,
-        # but we move it to the factory so we can
-        # populate the test account properly (and only once
-        # per session)
 
     #############################################################
     #
@@ -181,10 +156,6 @@ class LEAPIMAPServer(imap4.IMAP4Server):
         :param line: the line from the server, without the line delimiter.
         :type line: str
         """
-        if self.theAccount.session_ended is True and self.state != "unauth":
-            log.msg("Closing the session. State: unauth")
-            self.state = "unauth"
-
         if "login" in line.lower():
             # avoid to log the pass, even though we are using a dummy auth
             # by now.
@@ -208,24 +179,6 @@ class LEAPIMAPServer(imap4.IMAP4Server):
             self.mbox = None
         self.state = 'unauth'
 
-    def authenticateLogin(self, username, password):
-        """
-        Lookup the account with the given parameters, and deny
-        the improper combinations.
-
-        :param username: the username that is attempting authentication.
-        :type username: str
-        :param password: the password to authenticate with.
-        :type password: str
-        """
-        # XXX this should use portal:
-        # return portal.login(cred.credentials.UsernamePassword(user, pass)
-        if username != self._userid:
-            # bad username, reject.
-            raise cred.error.UnauthorizedLogin()
-        # any dummy password is allowed so far. use realm instead!
-        emit_async(catalog.IMAP_CLIENT_LOGIN, username, "1")
-        return imap4.IAccount, self.theAccount, lambda: None
 
     def do_FETCH(self, tag, messages, query, uid=0):
         """

--- a/src/leap/mail/imap/service/imap-server.tac
+++ b/src/leap/mail/imap/service/imap-server.tac
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # imap-server.tac
 # Copyright (C) 2013,2014 LEAP
@@ -27,6 +28,9 @@ userid = 'user@provider'
 uuid = 'deadbeefdeadabad'
 passwd = 'supersecret' # optional, will get prompted if not found.
 """
+
+# TODO -- this .tac file should be deprecated in favor of bitmask.core.bitmaskd
+
 import ConfigParser
 import getpass
 import os
@@ -112,7 +116,7 @@ tempdir = "/tmp/"
 
 print "[~] user:", userid
 soledad = initialize_soledad(uuid, userid, passwd, secrets,
-                             localdb, gnupg_home, tempdir)
+                             localdb, gnupg_home, tempdir, userid=userid)
 km_args = (userid, "https://localhost", soledad)
 km_kwargs = {
     "token": "",
@@ -131,7 +135,8 @@ keymanager = KeyManager(*km_args, **km_kwargs)
 
 
 def getIMAPService():
-    factory = imap.LeapIMAPFactory(uuid, userid, soledad)
+    soledad_sessions = {userid: soledad}
+    factory = imap.LeapIMAPFactory(soledad_sessions)
     return internet.TCPServer(port, factory, interface="localhost")
 
 

--- a/src/leap/mail/imap/tests/test_imap.py
+++ b/src/leap/mail/imap/tests/test_imap.py
@@ -575,8 +575,8 @@ class LEAPIMAP4ServerTestCase(IMAP4HelperMixin):
         """
         Test login requiring quoting
         """
-        self.server._userid = '{test}user@leap.se'
-        self.server._password = '{test}password'
+        self.server.checker.userid = '{test}user@leap.se'
+        self.server.checker.password = '{test}password'
 
         def login():
             d = self.client.login('{test}user@leap.se', '{test}password')

--- a/src/leap/mail/imap/tests/utils.py
+++ b/src/leap/mail/imap/tests/utils.py
@@ -77,14 +77,11 @@ class IMAP4HelperMixin(SoledadTestMixin):
 
         soledad_adaptor.cleanup_deferred_locks()
 
-        UUID = 'deadbeef',
         USERID = TEST_USER
 
         def setup_server(account):
             self.server = LEAPIMAPServer(
-                uuid=UUID, userid=USERID,
-                contextFactory=self.serverCTX,
-                soledad=self._soledad)
+                contextFactory=self.serverCTX)
             self.server.theAccount = account
 
             d_server_ready = defer.Deferred()

--- a/src/leap/mail/outgoing/service.py
+++ b/src/leap/mail/outgoing/service.py
@@ -71,7 +71,7 @@ class OutgoingMail:
 
     def __init__(self, from_address, keymanager, cert, key, host, port):
         """
-        Initialize the mail service.
+        Initialize the outgoing mail service.
 
         :param from_address: The sender address.
         :type from_address: str

--- a/src/leap/mail/smtp/gateway.py
+++ b/src/leap/mail/smtp/gateway.py
@@ -49,6 +49,9 @@ from email import generator
 generator.Generator = RFC3156CompliantGenerator
 
 
+# TODO -- implement Queue using twisted.mail.mail.MailService
+
+
 #
 # Helper utilities
 #


### PR DESCRIPTION
==Work in progress.==
This will be needed to try the latest bonafide/bitmask.core stuff.
This will also need some adjustments in the current initialization in the bitmask client.