### PR TITLE
[tests] fix missing pycryptopp dependency and mock async calls

### DIFF
--- a/pkg/requirements-latest.pip
+++ b/pkg/requirements-latest.pip
@@ -1,5 +1,7 @@
 --index-url https://pypi.python.org/simple/
 
+pycryptopp
+
 --allow-external u1db  --allow-unverified u1db
 --allow-external dirspec  --allow-unverified dirspec
 -e 'git+https://github.com/pixelated-project/leap_pycommon.git@develop#egg=leap.common'

--- a/src/leap/mail/generator.py
+++ b/src/leap/mail/generator.py
@@ -1,5 +1,6 @@
 from email.generator import Generator as EmailGenerator
 
+
 class Generator(EmailGenerator):
     """
     Generates output from a Message object tree, keeping signatures.

--- a/src/leap/mail/tests/__init__.py
+++ b/src/leap/mail/tests/__init__.py
@@ -94,6 +94,8 @@ class TestCaseWithKeyManager(unittest.TestCase, BaseLeapTest):
                               gpgbinary=self.GPG_BINARY_PATH)
         self._km._fetcher.put = Mock()
         self._km._fetcher.get = Mock(return_value=Response())
+        self._km._async_client.request = Mock(return_value="")
+        self._km._async_client_pinned.request = Mock(return_value="")
 
         d1 = self._km.put_raw_key(PRIVATE_KEY, OpenPGPKey, ADDRESS)
         d2 = self._km.put_raw_key(PRIVATE_KEY_2, OpenPGPKey, ADDRESS_2)


### PR DESCRIPTION
- leap_mail still uses pycryptopp and therefore still needs the
  dependency
- Keymanager calls to async HTTPClient had not been mocked, causing
  a test to fail
- fixed a pep8 warning