### PR TITLE
Fix verify signature on encrypted email from Apple Mail

### DIFF
--- a/src/leap/mail/incoming/service.py
+++ b/src/leap/mail/incoming/service.py
@@ -506,7 +506,6 @@ class IncomingMail(Service):
         # decrypt or fail gracefully
         def build_msg(res):
             decrdata, signkey = res
-
             decrmsg = self._parser.parsestr(decrdata)
             # remove original message's multipart/encrypted content-type
             del(msg['content-type'])
@@ -524,10 +523,20 @@ class IncomingMail(Service):
             self._add_decrypted_header(msg)
             return (msg, signkey)
 
+        def verify_signature_after_decrypt_an_email(res):
+            decrdata, signkey = res
+            if not isinstance(signkey, OpenPGPKey):
+                try:
+                    return self._verify_signature_not_encrypted_msg(decrdata, senderAddress)
+                except:
+                    pass
+            return res
+
         d = self._keymanager.decrypt(
             encdata, self._userid, OpenPGPKey,
             verify=senderAddress)
         d.addCallbacks(build_msg, self._decryption_error, errbackArgs=(msg,))
+        d.addCallbacks(verify_signature_after_decrypt_an_email)
         return d
 
     def _maybe_decrypt_inline_encrypted_msg(self, origmsg, encoding,


### PR DESCRIPTION
The leap.mail has a step that decrypt an email and at the same time it should verify signature.
It works when using Thunderbird to send an email, but when using Apple Mail that step always return "could not verify signature" because of the way that Apple Mail encrypt and sign the email.

Issue: https://github.com/pixelated/pixelated-user-agent/issues/605
