### PR TITLE
[feature] use same token for imap/stmp authentication

### DIFF
--- a/src/leap/mail/imap/service/imap.py
+++ b/src/leap/mail/imap/service/imap.py
@@ -87,8 +87,10 @@ class LocalSoledadIMAPRealm(object):
 
 
 class IMAPTokenChecker(LocalSoledadTokenChecker):
-    """A credentials checker that will lookup a token for the IMAP service."""
-    service = 'imap'
+    """A credentials checker that will lookup a token for the IMAP service.
+    For now it will be using the same identifier than SMTPTokenChecker"""
+
+    service = 'mail_auth'
 
 
 class LocalSoledadIMAPServer(LEAPIMAPServer):

--- a/src/leap/mail/smtp/gateway.py
+++ b/src/leap/mail/smtp/gateway.py
@@ -144,8 +144,10 @@ class LocalSMTPRealm(object):
 
 
 class SMTPTokenChecker(LocalSoledadTokenChecker):
-    """A credentials checker that will lookup a token for the SMTP service."""
-    service = 'smtp'
+    """A credentials checker that will lookup a token for the SMTP service.
+    For now it will be using the same identifier than IMAPTokenChecker"""
+
+    service = 'mail_auth'
 
     # TODO besides checking for token credential,
     # we could also verify the certificate here.


### PR DESCRIPTION
This greatly simplifies the handling of the password in the thunderbird
extension.

Related: #6041