### PR TITLE
[bug] fix CHANGELOG.rst open in setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include pkg/*
 include versioneer.py
 include LICENSE
-include CHANGELOG
+include CHANGELOG.rst
 include README.rst
 include src/leap/mail/_version.py

--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ setup(
     maintainer_email='kali@leap.se',
     description='Mail Services provided by Bitmask, the LEAP Client.',
     long_description=open('README.rst').read() + '\n\n\n' +
-    open('CHANGELOG').read(),
+    open('CHANGELOG.rst').read(),
     classifiers=trove_classifiers,
     namespace_packages=["leap"],
     package_dir={'': 'src'},


### PR DESCRIPTION
The name of the `CHANGELOG` file was changed some weeks ago to `CHANGELOG.rst` but the `setup.py` script was not changed accordingly.