### PR TITLE
[bug] cast the identity to bytes

### DIFF
--- a/changes/next-changelog.rst
+++ b/changes/next-changelog.rst
@@ -1,4 +1,4 @@
-0.4.1 - xxx
+0.4.2 - xxx
 +++++++++++++++++++++++++++++++
 
 Please add lines to this file, they will be moved to the CHANGELOG.rst during
@@ -10,21 +10,12 @@ I've added a new category `Misc` so we can track doc/style/packaging stuff.
 
 Features
 ~~~~~~~~
-- `#7656 <https://leap.se/code/issues/7656>`_: Emit multi-user aware events.
-- `#4008 <https://leap.se/code/issues/4008>`_: Add token-based authentication to local IMAP/SMTP services.
-- `#7889 <https://leap.se/code/issues/7889>`_: Use cryptography instead of pycryptopp to reduce dependencies.
-- `#7263 <https://leap.se/code/issues/7263>`_: Implement local bounces to notify user of SMTP delivery errors.
-- Use twisted.cred to authenticate IMAP users.
-
 - `#1234 <https://leap.se/code/issues/1234>`_: Description of the new feature corresponding with issue #1234.
 - New feature without related issue number.
 
 Bugfixes
 ~~~~~~~~
-- `#7861 <https://leap.se/code/issues/7861>`_: Use the right succeed function for passthrough encrypted email.
-- `#7898 <https://leap.se/code/issues/7898>`_: Fix IMAP fetch headers
-- `#7977 <https://leap.se/code/issues/7977>`_: Decode attached keys so they are recognized by keymanager.
-- Fix the get_body logic for corner-cases in which body is None (yet-to-be synced docs, mainly).
+- Cast local identity (version string) to bytes, avoid TLS transport raising exception.
 
 - `#1235 <https://leap.se/code/issues/1235>`_: Description for the fixed stuff corresponding with issue #1235.
 - Bugfix without related issue number.

--- a/src/leap/mail/outgoing/service.py
+++ b/src/leap/mail/outgoing/service.py
@@ -224,7 +224,7 @@ class OutgoingMail(object):
             heloFallback=True,
             requireAuthentication=False,
             requireTransportSecurity=True)
-        factory.domain = __version__
+        factory.domain = bytes('leap.mail-' + __version__)
         emit_async(catalog.SMTP_SEND_MESSAGE_START,
                    self._from_address, recipient.dest.addrstr)
         reactor.connectSSL(


### PR DESCRIPTION
This fixes a bug in which the tls transport complains about receiving
unicode. It was only made evident by running against twisted 16.