### PR TITLE
[bug] Allow pixelated integration not to interfere with thunderbird

### DIFF
--- a/changes/next-changelog.rst
+++ b/changes/next-changelog.rst
@@ -15,6 +15,7 @@ Features
 
 Bugfixes
 ~~~~~~~~
+- `#8083 <https://leap.se/code/issues/8083>`_: Allow pixelated UA not interfere with Thunderbird operation.
 - Cast local identity (version string) to bytes, avoid TLS transport raising exception.
 
 - `#1235 <https://leap.se/code/issues/1235>`_: Description for the fixed stuff corresponding with issue #1235.

--- a/src/leap/mail/imap/mailbox.py
+++ b/src/leap/mail/imap/mailbox.py
@@ -91,6 +91,9 @@ def make_collection_listener(mailbox):
         def __init__(self, mbox):
             self.mbox = mbox
 
+            # See #8083, pixelated adaptor seems to be misusing this class.
+            self.mailbox_name = self.mbox.mbox_name
+
         def __hash__(self):
             return hash(self.mbox.mbox_name)
 


### PR DESCRIPTION
One of the pixelated adaptors was trying to access a non-existing
attribute in HashableMailbox, which for some reason was blocking the
operation of the imap server (uncatched exception in listeners call
maybe).

adding an attribute skips this error and therefore allows seamless use
of both pixelated and thunderbird user agents at the same time.

Resolves: #8083