### PR TITLE
Add not called asserts to testDecryptEmail

### DIFF
--- a/src/leap/mail/incoming/tests/test_incoming_mail.py
+++ b/src/leap/mail/incoming/tests/test_incoming_mail.py
@@ -293,6 +293,8 @@ subject: independence of cyberspace
         d.addCallback(
             lambda message:
             self._do_fetch(message.as_string()))
+        d.addCallback(decryption_error_not_called)
+        d.addCallback(add_decrypted_header_called)
         return d
 
     def testListener(self):


### PR DESCRIPTION
The functions decryption_error_not_called and add_decrypted_header_called
were not being called on testDecryptEmail. So the asserts was not being
called as well.

This change adds the above functions as callbacks to be called after the
fetch method.