### PR TITLE
[bug] initialize OpenSSL context just once in leap.mail

### DIFF
--- a/src/leap/mail/walk.py
+++ b/src/leap/mail/walk.py
@@ -24,10 +24,11 @@ from cryptography.hazmat.primitives import hashes
 
 from leap.mail.utils import first
 
+crypto_backend = MultiBackend([OpenSSLBackend()])
+
 
 def get_hash(s):
-    backend = MultiBackend([OpenSSLBackend()])
-    digest = hashes.Hash(hashes.SHA256(), backend)
+    digest = hashes.Hash(hashes.SHA256(), crypto_backend)
     digest.update(s)
     return digest.finalize().encode("hex").upper()
 


### PR DESCRIPTION
Do not initialize the openssl context on each call to get mail payload phash.

The openSSL backend should only be initialized once because it is activating the os random engine
which in turn unregister and free the current engine first. This is very tricky when operations are running in threads as it  momentarily unregister the openssl crypto callbacks that makes openssl thread safe.

- Resolves: #8180 with the soledad PR #324